### PR TITLE
chore: change examples to use cx23 instances

### DIFF
--- a/examples/server/ts/index.ts
+++ b/examples/server/ts/index.ts
@@ -12,7 +12,7 @@ const subnet = new hcloud.NetworkSubnet("subnet", {
 });
 
 new hcloud.Server("server", {
-    serverType: "cx22",
-    image: "ubuntu-22.04",
+    serverType: "cx23",
+    image: "ubuntu-24.04",
     networks: [{ networkId: network.id.apply(Number) }],
 }, {dependsOn: subnet});

--- a/provider/test-programs/index_server/Pulumi.yaml
+++ b/provider/test-programs/index_server/Pulumi.yaml
@@ -11,8 +11,7 @@ resources:
   server:
     properties:
       image: ubuntu-24.04
-
-      serverType: cx22
+      serverType: cx23
       sshKeys:
         - ${ssh_key.id}
     type: hcloud:index/server:Server


### PR DESCRIPTION
The cx22 instance type has been deprecated
(https://docs.hetzner.cloud/changelog#2025-10-16-server-types-deprecated).
